### PR TITLE
Add release process back to GitHub actions (CI)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -30,9 +30,9 @@ jobs:
       run: go test -v ./...
 
     - name: Release
-        uses: softprops/action-gh-release@v2
-        # Only run on tags
-        if: startsWith(github.ref, 'refs/tags/')
-        with:
-          files: 'gocat' # only release the linux-amd64 version for now
+      uses: softprops/action-gh-release@v2
+      # Only run on tags
+      if: startsWith(github.ref, 'refs/tags/')
+      with:
+        files: 'gocat' # only release the linux-amd64 version for now
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,61 +29,10 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-# TODO(JZ): Re-enable the release after the base test and build workflow is working
-  #
-  # release:
-  #   name: Release
-  #   runs-on: ubuntu-latest
-  #   needs: [test]
-  #   if: startsWith(github.ref, 'refs/tags/')
-  #   steps:
-  #   - name: Download gox
-  #     run: go get github.com/mitchellh/gox
-  #
-  #   - name: Check out code into the Go module directory
-  #     uses: actions/checkout@v2
-  #
-  #   - name: Get Git tag
-  #     id: tag
-  #     run: echo ::set-output name=TAG::${GITHUB_REF#refs/tags/}
-  #
-  #   - name: Build release assets
-  #     run: |
-  #        $(go env GOPATH)/bin/gox \
-  #         -output='build/gocat-${{ steps.tag.outputs.TAG }}-{{ .OS }}-{{ .Arch }}' \
-  #         -arch='amd64' \
-  #         -os='linux darwin' \
-  #         -verbose \
-  #         -ldflags "-s -w"
-  #
-  #   - name: Create Release
-  #     id: create_release
-  #     uses: actions/create-release@v1
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     with:
-  #       tag_name: ${{ github.ref }}
-  #       release_name: ${{ github.ref }}
-  #       draft: false
-  #       prerelease: false
-  #       body: Changelog at https://github.com/sumup-oss/gocat/blob/master/CHANGELOG.md
-  #
-  #   # TODO: Replace with glob pattern once `actions/upload-release-asset` supports it
-  #   - uses: actions/upload-release-asset@v1
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     with:
-  #       upload_url: ${{ steps.create_release.outputs.upload_url }}
-  #       asset_path: ./build/gocat-${{ steps.tag.outputs.TAG }}-darwin-amd64
-  #       asset_name: gocat-${{ steps.tag.outputs.TAG }}-darwin-amd64
-  #       asset_content_type: application/octet-stream
-  #
-  #   # TODO: Replace with glob pattern once `actions/upload-release-asset` supports it
-  #   - uses: actions/upload-release-asset@v1
-  #     env:
-  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  #     with:
-  #       upload_url: ${{ steps.create_release.outputs.upload_url }}
-  #       asset_path: ./build/gocat-${{ steps.tag.outputs.TAG }}-linux-amd64
-  #       asset_name: gocat-${{ steps.tag.outputs.TAG }}-linux-amd64
-  #       asset_content_type: application/octet-stream
+    - name: Release
+        uses: softprops/action-gh-release@v2
+        # Only run on tags
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: 'gocat' # only release the linux-amd64 version for now
+


### PR DESCRIPTION
 This changes the old method which relied on archived GH Actions, to use https://github.com/softprops/action-gh-release instead. I also simplified the release so it _only_ released the Linux AMD64 version, since that is all we need.